### PR TITLE
Links bottom registry button

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@ layout: landing-page
 				<footer>
 					<ul class="buttons">
 						<li><a href="/rsvp" class="button special">RSVP</a></li>
-						<li><a href="#" class="button">Registry</a></li>
+						<li><a href="https://www.zola.com/registry/thaneyriordan/" class="button">Registry</a></li>
 					</ul>
 				</footer>
 


### PR DESCRIPTION
Second link to registry (in footer) was unlinked. Adds the link back.

Fixes #15
